### PR TITLE
Add HashTree data structure with several functions. See commit message for all changes

### DIFF
--- a/package-set.dhall
+++ b/package-set.dhall
@@ -4,7 +4,7 @@ let upstream =
 let packages = [
   { name = "stable-hash-map"
   , repo = "https://github.com/canscale/StableHashMap"
-  , version = "v0.2.0"
+  , version = "v0.2.1"
   , dependencies = [ "base" ]
   },
   { name = "stable-rbtree"

--- a/src/Entity.mo
+++ b/src/Entity.mo
@@ -64,9 +64,19 @@ module {
   };
 
   // TODO: may delete if not used elsewhere or as external dev user helper
-  public func createEntity(pk: PK, sk: SK, attributePairs: [(AttributeKey, AttributeValue)]): Entity = {
+  public func createEntity(pk: PK, sk: SK, attributeMap: AttributeMap): Entity = {
     pk = pk;
     sk = sk;
-    attributes = createAttributeMapFromPairs(attributePairs);
+    attributes = attributeMap;
+  };
+
+  public func equal(e1: Entity, e2: Entity): Bool {
+    Text.equal(e1.pk, e2.pk) and 
+    Text.equal(e1.sk, e2.sk) and 
+    attributeMapsEqual(e1.attributes, e2.attributes);
+  };
+
+  public func toText(e: Entity): Text {
+    "{ pk=" # e.pk # "; sk=" # e.sk # "; attributes=" # attributeMapToText(e.attributes) # " }"
   };
 }

--- a/src/HashTree.mo
+++ b/src/HashTree.mo
@@ -1,0 +1,212 @@
+import HM "mo:stable-hash-map/FunctionalStableHashMap";
+import RBT "mo:stable-rbtree/StableRBTree";
+import A "mo:base/Array";
+import Text "mo:base/Text";
+import Nat32 "mo:base/Nat32";
+import List "mo:base/List";
+import E "./Entity";
+import RT "./RangeTree";
+import AssocList "mo:base/AssocList";
+
+module {
+  public type HTKVs = AssocList.AssocList<E.PK, RT.RangeTree>;
+  public type HashTree = HM.StableHashMap<E.PK, RT.RangeTree>;
+
+
+  /// Initializes a StableHashTree with initCapacity and table size zero
+  public func init(): HashTree {
+    HM.init<E.PK, RT.RangeTree>();
+  };
+
+  public func initPreSized(initCapacity: Nat): HashTree {
+    HM.initPreSized<E.PK, RT.RangeTree>(initCapacity);
+  };
+
+  /* TODO: 
+   * If calculating from scratch, need to iterate through HashTree entries, and then each of the RTs
+   * Also consider holding a count variable at the root HashTree, as well as at each of the RTs
+   * Also possibly hold a count at the canister manager level.
+  public func count(ht: HashTree): Nat {
+  };
+  */
+
+  /// Gets an entity from the HashTree by pk + sk if that element exists
+  public func get(ht: HashTree, pk: E.PK, sk: E.SK): ?E.Entity {
+    switch(HM.get<E.PK, RT.RangeTree>(ht, Text.equal, Text.hash, pk)) {
+      case null { null };
+      case (?rt) {
+        switch(RT.get(rt, sk)) {
+          case null { null };
+          case (?attributeMap) { ?E.createEntity(pk, sk, attributeMap) }
+        }
+      }
+    }
+  };
+
+  /// Insert/Replace an entity into the HashTree and returns nothing
+  /// Mutates the underlying HashTree passed to this function
+  public func put(ht: HashTree, entity: E.Entity): () {
+    ignore replace(ht, entity);
+  };
+
+  /// Insert/Replace an entity into the HashTree and returns the previous value stored at
+  /// the pk + sk if existed.
+  /// Mutates the underlying HashTree passed to this function
+  public func replace(ht: HashTree, entity: E.Entity): ?E.Entity {
+    if (ht._count >= ht.table.size()) {
+      ht.table := resizeTable(ht);
+    };
+    let h = Nat32.toNat(Text.hash(entity.pk));
+    let pos = h % ht.table.size();
+
+    let (kvs2, ov) = replaceRec(ht.table[pos], entity);
+    ht.table[pos] := kvs2;
+    switch(ov) {
+      case null { ht._count += 1 };
+      case _ {}
+    };
+    ov;
+  };
+
+  /// Deletes an entity from the HashTree by pk/sk if that entity exists. Does not return any value
+  /// Mutates the underlying HashTree passed to this function
+  public func delete(ht: HashTree, pk: E.PK, sk: E.SK): () {
+    ignore remove(ht, pk, sk);
+  };
+
+  /// Deletes an entity from the HashTree by pk/sk if that entity exists, and returns the original value if that entity exists
+  /// Mutates the underlying HashTree passed to this function
+  public func remove(ht: HashTree, pk: E.PK, sk: E.SK): ?E.Entity {
+    let m = ht.table.size();
+    if (m > 0) {
+      let h = Nat32.toNat(Text.hash(pk));
+      let pos = h % m;
+      let (kvs2, ov) = removeRec(ht.table[pos], pk, sk);
+      ht.table[pos] := kvs2;
+
+      ov;
+    } else {
+      null
+    }
+  };
+
+  // TODO: Think about the case where deleting an element from a range tree leaves an empty range tree
+  // (i.e. should this RT be deleted from the al, and if the al is now empty, should the hash table be removed and the size decremented?)
+  /// Return a boolean indicating if the two HashTrees are equivalent, ignoring deleted entries in the underlying RangeTree Red-Black Tree
+  public func equal(ht1: HashTree, ht2: HashTree): Bool {
+    func hashTreeEntryEqual((pk1: E.PK, rt1: RT.RangeTree), (pk2: E.PK, rt2: RT.RangeTree)): Bool {
+      Text.equal(pk1, pk2) and RT.equal(rt1, rt2);
+    };
+
+    if (HM.size<E.PK, RT.RangeTree>(ht1) != HM.size<E.PK, RT.RangeTree>(ht2)) { 
+      return false
+    };
+    var i = 0;
+    while (i < HM.size<E.PK, RT.RangeTree>(ht1)) {
+      if (not List.equal<(E.PK, RT.RangeTree)>(ht1.table[i], ht2.table[i], hashTreeEntryEqual)) {
+        return false;
+      };
+      i += 1;
+    }; 
+    return true;
+  };
+
+  // insert the entity into the hashtable at the hashed position
+  // if text of the pk exists, replaces it
+  // if there is a hash collection, inserts itself by appending the entity to the list at that hash value
+  // if there is nothing at the hash table position, inserts the entity 
+  func replaceRec(al: HTKVs, entity: E.Entity): (HTKVs, ?E.Entity) {
+    switch (al) {
+      // key does not exist at hash table or collision list position
+      case null {
+        (?((entity.pk, RT.put(RT.init(), entity)), null), null);
+      };
+      // a key (matching or collision exists at hash table position)
+      case (?((pk, rangeTree), tl)) {
+        // key exists, replace at the RangeTree level
+        if (Text.equal(pk, entity.pk)) {
+          switch(RT.replace(rangeTree, entity)) {
+            case (null, newRT) {
+              (?((pk, newRT), tl), null)
+            };
+            case (?ovAttrMap, newRT) {
+              (?((pk, newRT), tl), ?{
+                pk = pk;
+                sk = entity.sk;
+                attributes = ovAttrMap;
+              })
+            }
+          }
+        // key does not match (collision), recurse on next element of collision list
+        } else {
+          let (nt, ov) = replaceRec(tl, entity);
+          (?((pk, rangeTree), nt), ov);
+        }
+      } 
+    }
+  }; 
+
+  func removeRec(al: HTKVs, pkRemove: E.PK, skRemove: E.SK): (HTKVs, ?E.Entity) {
+    switch (al) {
+      // key does not exist at hash table or collision list position
+      case null {
+        (null, null);
+      };
+      // a key (matching or collision exists at hash table position)
+      case (?((pk, rangeTree), tl)) {
+        // pk exists, replace at the RangeTree level
+        if (Text.equal(pk, pkRemove)) {
+          switch(RT.remove(rangeTree, skRemove)) {
+            // sk does not exist, remove nothing
+            case (null, _) {
+              (al, null)
+            };
+            case (?ovAttrMap, newRT) {
+              (?((pk, newRT), tl), ?{
+                pk = pkRemove;
+                sk = skRemove;
+                attributes = ovAttrMap;
+              })
+            }
+          }
+        // key does not match (collision), recurse on next element of collision list
+        } else {
+          let (nt, ov) = removeRec(tl, pkRemove, skRemove);
+          (?((pk, rangeTree), nt), ov);
+        }
+      } 
+    }
+  };
+
+  func resizeTable(ht: HashTree): [var HTKVs] {
+    let size = 
+      if (ht._count == 0) {
+        if (ht.initCapacity > 0) {
+          ht.initCapacity
+        } else {
+          1
+        }
+      }
+      else {
+        ht.table.size() * 2;
+      };
+    let table2 = A.init<HTKVs>(size, null); 
+    for (i in ht.table.keys()) {
+      var kvs = ht.table[i];
+      label moveKeyVals: ()
+      loop {
+        switch kvs {
+          case null { break moveKeyVals };
+          case (?((k, v), kvsTail)) {
+            let h = Nat32.toNat(Text.hash(k));
+            let pos2 = h % table2.size();
+            table2[pos2] := ?((k,v), table2[pos2]);
+            kvs := kvsTail;
+          };
+        }
+      };
+    };
+    table2;
+  };
+
+}

--- a/src/RangeTree.mo
+++ b/src/RangeTree.mo
@@ -41,6 +41,11 @@ module {
     RBT.delete<E.SK, E.AttributeMap>(rt, Text.compare, sk);
   };
 
+  //TODO: write unit tests for this
+  public func remove(rt: RangeTree, sk: E.SK): (?E.AttributeMap, RangeTree) {
+    RBT.remove<E.SK, E.AttributeMap>(rt, Text.compare, sk)
+  };
+
   public func scan(rt: RangeTree, skLowerBound: E.SK, skUpperBound: E.SK): [(E.SK, E.AttributeMap)] {
     switch(Text.compare(skLowerBound, skUpperBound)) {
       case (#greater) { [] };

--- a/test/HashTreeMatchers.mo
+++ b/test/HashTreeMatchers.mo
@@ -1,0 +1,60 @@
+import M "mo:matchers/Matchers";
+import T "mo:matchers/Testable";
+import HT "../src/HashTree";
+import E "../src/Entity";
+import RT "../src/RangeTree";
+import Buffer "mo:base/Buffer";
+import Array "mo:base/Array";
+
+/// This module contains Testable typed helpers functions for the tests in HashTreeTest.mo 
+module {
+  public func testableHashTree(ht: HT.HashTree): T.TestableItem<HT.HashTree> = {
+    display = func(ht: HT.HashTree): Text = "";
+    equals = func(ht1: HT.HashTree, ht2: HT.HashTree): Bool = HT.equal(ht1, ht2);
+    item = ht;
+  };
+
+  // Note: just for use in tests - gets all entries in a HashTree (keep this in test and not src b/c can be expensive to run)
+  public func entries(ht: HT.HashTree): [E.Entity] {
+    let buffer = Buffer.Buffer<E.Entity>(1);
+
+    for (entry in ht.table.vals()) {
+      // get all entities for a specific pk (index)
+      switch(entry) {
+        case null {};
+        case (?((pk, rt), tl)) {
+          for ((sk, attributeMap) in RT.entries(rt)) {
+            buffer.add(
+              {
+                pk = pk;
+                sk = sk;
+                attributes = attributeMap;
+              }
+            )
+          }
+        }
+      }
+    };
+
+    buffer.toArray();
+  };
+
+  public let testableEntity: T.Testable<E.Entity> = {
+    display = E.toText;
+    equals = E.equal;
+  };
+
+  public func testableHashTreeEntries(entityArray: [E.Entity]): T.TestableItem<[E.Entity]> = {
+    display = func(entityArray: [E.Entity]): Text {
+      var output = "[";
+      for (e in entityArray.vals()) {
+        output #= E.toText(e) # ",";
+      };
+      output # "]"
+    };
+    equals = func(a1: [E.Entity], a2: [E.Entity]): Bool {
+      Array.equal(a1, a2, E.equal)
+    };
+    item = entityArray;
+  }
+}

--- a/test/HashTreeTest.mo
+++ b/test/HashTreeTest.mo
@@ -1,0 +1,387 @@
+import M "mo:matchers/Matchers";
+import S "mo:matchers/Suite";
+import T "mo:matchers/Testable";
+import RT "../src/RangeTree";
+import HT "../src/HashTree";
+import HTM "./HashTreeMatchers";
+import HM "mo:stable-hash-map/FunctionalStableHashMap";
+import E "../src/Entity";
+import TH "./TestHelpers";
+
+let { run;test;suite; } = S;
+
+let initSuite = suite("init", 
+  [
+    test("initializes a hashmap of type E.PK, RangeTree",
+      HT.init(),
+      M.equals(HTM.testableHashTree(
+        HM.init<E.PK, RT.RangeTree>()
+      ))
+    ),
+    test("has a size of 0",
+      HM.size<E.PK, RT.RangeTree>(HT.init()),
+      M.equals(T.nat(0))
+    )
+  ]
+);
+
+let mockAttributes = TH.createMockAttributes("Cleveland");
+
+let putSuite = suite("put", 
+  [
+    test("inserts an item into an empty HashTree",
+      do {
+        let ht = HT.init();
+        HT.put(ht, {
+          pk = "app1";
+          sk = "john";
+          attributes = mockAttributes; 
+        });
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app1"; sk = "john"; attributes = mockAttributes }
+      ]))
+    ),
+    test("inserts items with different pks into a HashTree",
+      do {
+        HTM.entries(
+          TH.createHashTreeWithPKSKMockEntries([
+            ("app1", "john"),
+            ("app2", "dave"),
+            ("app3", "shelly"),
+          ])
+        )
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app2"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app3"; sk = "shelly"; attributes = mockAttributes },
+        { pk = "app1"; sk = "john"; attributes = mockAttributes },
+      ]))
+    ),
+    test("inserts items with different pks and multiple sks per pk into a HashTree, and the items entries are grouped in sk order by pk",
+      do {
+        HTM.entries(
+          TH.createHashTreeWithPKSKMockEntries([
+            ("app1", "john"),
+            ("app1", "steve"),
+            ("app1", "clara"),
+            ("app2", "dave"),
+            ("app2", "abigail"),
+            ("app3", "shelly"),
+            ("app3", "bruce"),
+            ("app3", "gail"),
+            ("app4", "shawn"),
+          ])
+        )
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app1"; sk = "clara"; attributes = mockAttributes },
+        { pk = "app1"; sk = "john"; attributes = mockAttributes },
+        { pk = "app1"; sk = "steve"; attributes = mockAttributes },
+        { pk = "app2"; sk = "abigail"; attributes = mockAttributes },
+        { pk = "app2"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app3"; sk = "bruce"; attributes = mockAttributes },
+        { pk = "app3"; sk = "gail"; attributes = mockAttributes },
+        { pk = "app3"; sk = "shelly"; attributes = mockAttributes },
+        { pk = "app4"; sk = "shawn"; attributes = mockAttributes },
+      ]))
+    ),
+    test("replaces an entry if it already exists at the root of an sk's RangeTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "john"),
+          ("app2", "dave"),
+          ("app3", "shelly"),
+        ]);
+        HT.put(ht, { pk = "app2"; sk = "dave"; attributes = TH.createMockAttributes("Columbus") });
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app2"; sk = "dave"; attributes = TH.createMockAttributes("Columbus") },
+        { pk = "app3"; sk = "shelly"; attributes = mockAttributes },
+        { pk = "app1"; sk = "john"; attributes = mockAttributes },
+      ]))
+    ),
+    test("replaces an entry if it exists deep in a sk's RangeTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "john"),
+          ("app1", "dave"),
+          ("app1", "shelly"),
+          ("app1", "alice"),
+          ("app1", "bruce"),
+          ("app1", "abigail"),
+        ]);
+        HT.put(ht, { pk = "app1"; sk = "alice"; attributes = TH.createMockAttributes("Columbus") });
+        HT.put(ht, { pk = "app1"; sk = "shelly"; attributes = TH.createMockAttributes("Akron") });
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app1"; sk = "abigail"; attributes = mockAttributes },
+        { pk = "app1"; sk = "alice"; attributes = TH.createMockAttributes("Columbus") },
+        { pk = "app1"; sk = "bruce"; attributes = mockAttributes },
+        { pk = "app1"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app1"; sk = "john"; attributes = mockAttributes },
+        { pk = "app1"; sk = "shelly"; attributes = TH.createMockAttributes("Akron") },
+      ]))
+    ),
+  ]
+);
+
+let getSuite = suite("get",
+  [
+    test("returns null if used on an empty HashTree",
+      do {
+        let entity = HT.get(HT.init(), "app1", "john");
+        T.optional<E.Entity>(HTM.testableEntity, entity);
+      },
+      M.isNull<E.Entity>()
+    ),
+    test("returns null if the pk does not exist",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app2", "shelly"),
+          ("app3", "dave"),
+        ]);
+        let entity = HT.get(ht, "app1", "john");
+        T.optional<E.Entity>(HTM.testableEntity, entity);
+      },
+      M.isNull<E.Entity>()
+    ),
+    test("returns null if the sk does not exist",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "shelly"),
+          ("app1", "dave"),
+        ]);
+        let entity = HT.get(ht, "app1", "john");
+        T.optional<E.Entity>(HTM.testableEntity, entity);
+      },
+      M.isNull<E.Entity>()
+    ),
+    test("returns the entity if it exists and is the only item in the hashtree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "dave"),
+        ]);
+        HT.get(ht, "app1", "dave");
+      },
+      M.equals<?E.Entity>(T.optional(HTM.testableEntity, ?{
+        pk = "app1";
+        sk = "dave";
+        attributes = TH.createMockAttributes("Cleveland")
+      }))
+    ),
+    test("returns the entity if it exists in a range tree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "dave"),
+          ("app1", "john"),
+          ("app1", "barry"),
+          ("app1", "alice"),
+          ("app2", "barry"),
+        ]);
+        HT.get(ht, "app1", "barry");
+      },
+      M.equals<?E.Entity>(T.optional(HTM.testableEntity, ?{
+        pk = "app1";
+        sk = "barry";
+        attributes = TH.createMockAttributes("Cleveland")
+      }))
+    ),
+  ]
+);
+
+let removeSuite = suite("remove",
+  [
+    test("remove on an empty HashTree returns null",
+      do {
+        let ht = HT.init();
+        let entity = HT.remove(ht, "app1", "john");
+        T.optional<E.Entity>(HTM.testableEntity, entity);
+      },
+      M.isNull<E.Entity>()
+    ),
+    test("remove on an empty HashTree does not modify the HashTree",
+      do {
+        let ht = HT.init();
+        let entity = HT.remove(ht, "app1", "john");
+        ht;
+      },
+      M.equals(HTM.testableHashTree(HT.init()))
+    ),
+    test("remove on a HashTree that does not contain the pk returns null",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "shelly"),
+          ("app1", "dave"),
+        ]);
+        let entity = HT.remove(ht, "app2", "shelly");
+        T.optional<E.Entity>(HTM.testableEntity, entity);
+      },
+      M.isNull<E.Entity>()
+    ),
+    test("remove on a HashTree that contains the pk, but not the sk returns null",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "shelly"),
+          ("app1", "dave"),
+        ]);
+        let entity = HT.remove(ht, "app1", "john");
+        T.optional<E.Entity>(HTM.testableEntity, entity);
+      },
+      M.isNull<E.Entity>()
+    ),
+    test("remove on a HashTree that contains the pk and sk returns the removed entry",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "shelly"),
+          ("app1", "dave"),
+        ]);
+        HT.remove(ht, "app1", "dave");
+      },
+      M.equals<?E.Entity>(T.optional(HTM.testableEntity, ?{
+        pk = "app1";
+        sk = "dave";
+        attributes = TH.createMockAttributes("Cleveland");
+      }))
+    ),
+    test("remove on a HashTree that contains the pk, but not the sk does not modify the HashTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "shelly"),
+          ("app1", "dave"),
+        ]);
+        let entity = HT.remove(ht, "app1", "john");
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app1"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app1"; sk = "shelly"; attributes = mockAttributes },
+      ]))
+    ),
+    test("remove on a HashTree with one entry that contains the pk and sk removes that entry from the HashTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "dave"),
+        ]);
+        let _ = HT.remove(ht, "app1", "dave");
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([]))
+    ),
+    test("remove on a HashTree with multiple different pk that contains the pk and sk returns that entry",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "john"),
+          ("app1", "steve"),
+          ("app2", "dave"),
+          ("app2", "abigail"),
+          ("app3", "shelly"),
+          ("app3", "bruce"),
+          ("app3", "gail"),
+        ]);
+        HT.remove(ht, "app3", "shelly");
+      },
+      M.equals<?E.Entity>(T.optional(HTM.testableEntity, ?{
+        pk = "app3";
+        sk = "shelly";
+        attributes = TH.createMockAttributes("Cleveland"); 
+      }))
+    ),
+    test("remove on a HashTree with multiple different pk that contains the pk and sk removes that entry from the HashTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "john"),
+          ("app1", "steve"),
+          ("app2", "dave"),
+          ("app2", "abigail"),
+          ("app3", "shelly"),
+          ("app3", "bruce"),
+          ("app3", "gail"),
+        ]);
+        let _ = HT.remove(ht, "app3", "shelly");
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app2"; sk = "abigail"; attributes = mockAttributes },
+        { pk = "app2"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app3"; sk = "bruce"; attributes = mockAttributes },
+        { pk = "app3"; sk = "gail"; attributes = mockAttributes },
+        { pk = "app1"; sk = "john"; attributes = mockAttributes },
+        { pk = "app1"; sk = "steve"; attributes = mockAttributes },
+      ]))
+    )
+  ]
+);
+
+let deleteSuite = suite("delete",
+  [
+    test("delete on an empty HashTree does not modify the HashTree",
+      do {
+        let ht = HT.init();
+        HT.delete(ht, "app1", "john");
+        ht;
+      },
+      M.equals(HTM.testableHashTree(HT.init()))
+    ),
+    test("delete on a HashTree that contains the pk, but not the sk does not modify the HashTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "shelly"),
+          ("app1", "dave"),
+        ]);
+        HT.delete(ht, "app1", "john");
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app1"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app1"; sk = "shelly"; attributes = mockAttributes },
+      ]))
+    ),
+    test("delete on a HashTree with one entry that contains the pk and sk removes that entry from the HashTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "dave"),
+        ]);
+        let _ = HT.delete(ht, "app1", "dave");
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([]))
+    ),
+    test("delete on a HashTree with multiple different pk that contains the pk and sk removes that entry from the HashTree",
+      do {
+        let ht = TH.createHashTreeWithPKSKMockEntries([
+          ("app1", "john"),
+          ("app1", "steve"),
+          ("app2", "dave"),
+          ("app2", "abigail"),
+          ("app3", "shelly"),
+          ("app3", "bruce"),
+          ("app3", "gail"),
+        ]);
+        let _ = HT.delete(ht, "app3", "shelly");
+        HTM.entries(ht);
+      },
+      M.equals(HTM.testableHashTreeEntries([
+        { pk = "app2"; sk = "abigail"; attributes = mockAttributes },
+        { pk = "app2"; sk = "dave"; attributes = mockAttributes },
+        { pk = "app3"; sk = "bruce"; attributes = mockAttributes },
+        { pk = "app3"; sk = "gail"; attributes = mockAttributes },
+        { pk = "app1"; sk = "john"; attributes = mockAttributes },
+        { pk = "app1"; sk = "steve"; attributes = mockAttributes },
+      ]))
+    )
+  ]
+);
+
+run(suite("HashTree", 
+  [
+    initSuite,
+    putSuite,
+    getSuite,
+    removeSuite,
+    deleteSuite,
+  ]
+));

--- a/test/RangeTreeTest.mo
+++ b/test/RangeTreeTest.mo
@@ -7,24 +7,14 @@ import RBT "mo:stable-rbtree/StableRBTree";
 import Text "mo:base/Text";
 import Iter "mo:base/Iter";
 import RTT "./RangeTreeMatchers";
+import TH "./TestHelpers";
 
 let { run;test;suite; } = S;
 
 //Setup
 
-// Test helper that creates mock attributes
-func createMockAttributes(city: Text): E.AttributeMap {
-  let attributes = [
-    ("state", #Text("OH")),
-    ("year", #Int(2020)),
-    ("city", #Text(city))
-  ];
-
-  E.createAttributeMapFromPairs(attributes);
-};
-
 // An AttributeMap value used throughout the tests
-let mockAttributes = createMockAttributes("Cleveland"); 
+let mockAttributes = TH.createMockAttributes("Cleveland"); 
 
 // Test helper that creates a RangeTree, then uses the put function to insert entities with the same PK and attributes,
 // but different sks into that RangeTree
@@ -102,13 +92,28 @@ let putSuite = suite("put",
       "replaces an entry if already exists",
       do {
         var rt = createRTAndPutSKs(["zack", "john"]);
-        rt := RT.put(rt, { pk = "app1"; sk = "zack"; attributes = createMockAttributes("Columbus")});
+        rt := RT.put(rt, { pk = "app1"; sk = "zack"; attributes = TH.createMockAttributes("Columbus")});
         Iter.toArray(RT.entries(rt));
       },
       M.equals(RTT.testableRangeTreeEntries(
         [
           ("john", mockAttributes),
-          ("zack", createMockAttributes("Columbus"))
+          ("zack", TH.createMockAttributes("Columbus"))
+        ]
+      ))
+    ),
+    test(
+      "inserts an entry correctly after it was previously deleted",
+      do {
+        var rt = createRTAndPutSKs(["zack", "john"]);
+        rt := RT.delete(rt, "zack");
+        rt := RT.put(rt, { pk = "app1"; sk = "zack"; attributes = TH.createMockAttributes("Columbus")});
+        Iter.toArray(RT.entries(rt));
+      },
+      M.equals(RTT.testableRangeTreeEntries(
+        [
+          ("john", mockAttributes),
+          ("zack", TH.createMockAttributes("Columbus"))
         ]
       ))
     ),
@@ -138,11 +143,11 @@ let getSuite = suite("get",
     test("after an entry was replaced multiple times, returns the most recent",
       do {
         var rt = createRTAndPutSKs(["john", "barry", "silvia"]);
-        rt := RT.put(rt, { pk = "app1"; sk = "barry"; attributes = createMockAttributes("Akron") });
-        rt := RT.put(rt, { pk = "app1"; sk = "barry"; attributes = createMockAttributes("Motoko!") });
+        rt := RT.put(rt, { pk = "app1"; sk = "barry"; attributes = TH.createMockAttributes("Akron") });
+        rt := RT.put(rt, { pk = "app1"; sk = "barry"; attributes = TH.createMockAttributes("Motoko!") });
         RT.get(rt, "barry"); 
       },
-      M.equals<?E.AttributeMap>(T.optional(RTT.testableAttributeMap, ?createMockAttributes("Motoko!")))
+      M.equals<?E.AttributeMap>(T.optional(RTT.testableAttributeMap, ?TH.createMockAttributes("Motoko!")))
     )
   ]
 );
@@ -234,13 +239,13 @@ let replaceSuite = suite("replace",
       "replaces an entry if already exists",
       do {
         var rt = createRTAndReplaceSKs(["zack", "john"]);
-        let (_, newRT) = RT.replace(rt, { pk = "app1"; sk = "zack"; attributes = createMockAttributes("Columbus")});
+        let (_, newRT) = RT.replace(rt, { pk = "app1"; sk = "zack"; attributes = TH.createMockAttributes("Columbus")});
         Iter.toArray(RT.entries(newRT));
       },
       M.equals(RTT.testableRangeTreeEntries(
         [
           ("john", mockAttributes),
-          ("zack", createMockAttributes("Columbus"))
+          ("zack", TH.createMockAttributes("Columbus"))
         ]
       ))
     ),
@@ -248,7 +253,7 @@ let replaceSuite = suite("replace",
       "returns the replaced map if it replaces an entry that already exists",
       do {
         var rt = createRTAndReplaceSKs(["zack", "john"]);
-        let (ov, _) = RT.replace(rt, { pk = "app1"; sk = "zack"; attributes = createMockAttributes("Columbus")});
+        let (ov, _) = RT.replace(rt, { pk = "app1"; sk = "zack"; attributes = TH.createMockAttributes("Columbus")});
         ov
       },
       M.equals<?E.AttributeMap>(T.optional(RTT.testableAttributeMap, ?mockAttributes))

--- a/test/TestHelpers.mo
+++ b/test/TestHelpers.mo
@@ -1,0 +1,31 @@
+import E "../src/Entity";
+import HT "../src/HashTree";
+import Text "mo:base/Text";
+
+/// This module contains helpers for setting up data structures in tests
+module {
+  // Test helper that creates mock attributes
+  public func createMockAttributes(city: Text): E.AttributeMap {
+    let attributes = [
+      ("state", #Text("OH")),
+      ("year", #Int(2020)),
+      ("city", #Text(city))
+    ];
+
+    E.createAttributeMapFromPairs(attributes);
+  };
+
+  // Test helper that creates a Hash Tree with the specified pk, sk, and fixed attributes
+  public func createHashTreeWithPKSKMockEntries(pksks: [(E.PK, E.SK)]): HT.HashTree {
+    let ht = HT.init();
+    let mockAttributes = createMockAttributes("Cleveland");
+    for ((pk, sk) in pksks.vals()) {
+      HT.put(ht, {
+        pk = pk;
+        sk = sk;
+        attributes = mockAttributes;
+      })
+    };
+    ht;
+  }
+}


### PR DESCRIPTION
* Add HashTree data structure with init(), initPresized(), get(), put(), replace(), delete(), remove(), and equal()
* Add HashTreeMatchers
* Modify Entity.createEntity function, add Entity.equal and Entity.toText functions
* Create refactor common test setup functions into TestHelpers
* Add RangeTree.remove() function
* Add previously deleted test to RangeTreeTest
* Update StableHashMap version in package-set.dhall to include fix to FunctionalStableHashMap.size()
* Add several TODOs