### PR TITLE
bump candy dependency and version of CanDB

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candb"
-version = "1.0.2"
+version = "1.0.3"
 description = " is a flexible, performant, and horizontally scalable non-relational multi-canister data store built for the Internet Computer."
 repository = "https://github.com/ORIGYN-SA/CanDB"
 
@@ -13,7 +13,7 @@ encoding = "https://github.com/aviate-labs/encoding.mo#v0.3.2"
 stable-rbtree = "https://github.com/canscale/StableRBTree#v0.6.1"
 stablebuffer = "https://github.com/skilesare/StableBuffer#v0.2.0"
 map = "https://github.com/ZhenyaUsenko/motoko-hash-map#v7.0.0"
-candy = "https://github.com/icdevs/candy_library#0.2.0"
+candy = "https://github.com/icdevs/candy_library#0.3.0"
 
 [dev-dependencies]
 test = "1.0.1"


### PR DESCRIPTION
When I was using the CanDB dependency with Mops, it had some difficulties in building nested dependencies with the latest DFX (0.15.2) and Mops. 

However, it seems that a simple bump of this dependency fixes the issue, and it doesn't break CanDB functionality in any way. If you find this proposed change meaningful, I would like to see it in your repository